### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,15 +6,15 @@ Creating rich and dry URLs for a Django model.
 
 |version| |python_version| |downloads|
 
-.. |version| image:: https://pypip.in/version/django-urlmodel/badge.svg?style=flat
+.. |version| image:: https://img.shields.io/pypi/v/django-urlmodel.svg?style=flat
     :target: https://pypi.python.org/pypi/django-urlmodel/
     :alt: Latest release
 
-.. |python_version| image:: https://pypip.in/py_versions/django-urlmodel/badge.svg?style=flat
+.. |python_version| image:: https://img.shields.io/pypi/pyversions/django-urlmodel.svg?style=flat
     :target: https://pypi.python.org/pypi/django-urlmodel/
     :alt: Python versions
     
-.. |downloads| image:: https://pypip.in/download/django-urlmodel/badge.svg?style=flat
+.. |downloads| image:: https://img.shields.io/pypi/dm/django-urlmodel.svg?style=flat
     :target: https://pypi.python.org/pypi/django-urlmodel/
     :alt: Downloads
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-urlmodel))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-urlmodel`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.